### PR TITLE
Remove JVM-specific code from common

### DIFF
--- a/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/Platform.kt
+++ b/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/Platform.kt
@@ -16,7 +16,19 @@
 package eu.europa.ec.eudi.statium
 
 import eu.europa.ec.eudi.statium.misc.Decompress
-import kotlinx.coroutines.Dispatchers
 import kotlin.coroutines.CoroutineContext
 
-internal expect fun platformDecompress(context: CoroutineContext = Dispatchers.IO): Decompress
+/**
+ * Returns a platform-specific CoroutineContext suitable for IO operations
+ */
+internal expect fun platformIoContext(): CoroutineContext
+
+/**
+ * Creates a platform-specific Decompress implementation
+ */
+internal expect fun platformDecompress(context: CoroutineContext): Decompress
+
+/**
+ * Creates a platform-specific Decompress implementation with the default IO context
+ */
+internal fun platformDecompress(): Decompress = platformDecompress(platformIoContext())

--- a/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/Types.kt
+++ b/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/Types.kt
@@ -125,9 +125,7 @@ public data class StatusList(
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as StatusList
+        if (other !is StatusList) return false
 
         if (bytesPerStatus != other.bytesPerStatus) return false
         if (!compressedList.contentEquals(other.compressedList)) return false
@@ -138,7 +136,7 @@ public data class StatusList(
 
     override fun hashCode(): Int {
         var result = bytesPerStatus.hashCode()
-        result = 31 * result + compressedList.contentHashCode()
+        result = 31 * result + compressedList.fold(0) { acc, byte -> 31 * acc + byte.toInt() }
         result = 31 * result + (aggregationUri?.hashCode() ?: 0)
         return result
     }

--- a/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/GetStatusTest.kt
+++ b/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/GetStatusTest.kt
@@ -16,7 +16,6 @@
 package eu.europa.ec.eudi.statium
 
 import io.ktor.client.*
-import jdk.internal.org.jline.utils.Status.getStatus
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
@@ -27,7 +26,8 @@ import kotlin.test.assertEquals
 
 class GetStatusTest {
 
-    @Test @Ignore
+    @Test
+    @Ignore
     fun testGetTokenStatusList() =
         doTest(
             expectedStatus = Status.Valid,

--- a/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/GetStatusTest.kt
+++ b/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/GetStatusTest.kt
@@ -16,7 +16,8 @@
 package eu.europa.ec.eudi.statium
 
 import io.ktor.client.*
-import kotlinx.coroutines.Dispatchers
+import jdk.internal.org.jline.utils.Status.getStatus
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
@@ -27,7 +28,7 @@ import kotlin.test.assertEquals
 class GetStatusTest {
 
     @Test @Ignore
-    fun testGetTokenStatusList() = runTest {
+    fun testGetTokenStatusList() =
         doTest(
             expectedStatus = Status.Valid,
             statusReference = StatusReference(
@@ -36,23 +37,22 @@ class GetStatusTest {
             ),
             Clock.fixed(Instant.parse("2025-03-27T13:02:23Z")),
         )
-    }
 }
 
 fun Clock.Companion.fixed(at: Instant): Clock = object : Clock {
     override fun now(): Instant = at
 }
 
-private suspend fun doTest(expectedStatus: Status, statusReference: StatusReference, clock: Clock = Clock.System) {
+private fun doTest(expectedStatus: Status, statusReference: StatusReference, clock: Clock = Clock.System) = runTest {
     with(getStatus(clock) { HttpClient() }) {
         val status = statusReference.status(at = null).getOrThrow()
         assertEquals(expectedStatus, status)
     }
 }
 
-private fun getStatus(clock: Clock, httpClientFactory: () -> HttpClient): GetStatus {
+private fun CoroutineScope.getStatus(clock: Clock, httpClientFactory: () -> HttpClient): GetStatus {
     val verifySignature = VerifyStatusListTokenSignature.Ignore
     val getStatusListToken = GetStatusListToken.usingJwt(clock, httpClientFactory, verifySignature)
-    val decompress = platformDecompress(Dispatchers.IO)
+    val decompress = platformDecompress(coroutineContext)
     return GetStatus(getStatusListToken, decompress)
 }

--- a/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/misc/ByteArrayAsBase64UrlNoPaddingSerializerTest.kt
+++ b/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/misc/ByteArrayAsBase64UrlNoPaddingSerializerTest.kt
@@ -115,9 +115,7 @@ class ByteArrayAsBase64UrlNoPaddingSerializerTest {
         data class TestData(val data: ByteArrayAsBase64UrlNoPadding) {
             override fun equals(other: Any?): Boolean {
                 if (this === other) return true
-                if (javaClass != other?.javaClass) return false
-
-                other as TestData
+                if (other !is TestData) return false
 
                 if (!data.contentEquals(other.data)) return false
 
@@ -125,7 +123,7 @@ class ByteArrayAsBase64UrlNoPaddingSerializerTest {
             }
 
             override fun hashCode(): Int {
-                return data.contentHashCode()
+                return data.fold(0) { acc, byte -> 31 * acc + byte.toInt() }
             }
         }
 

--- a/lib/src/jvmAndAndroidMain/kotlin/eu/europa/ec/eudi/statium/Platform.jvmAndAndroid.kt
+++ b/lib/src/jvmAndAndroidMain/kotlin/eu/europa/ec/eudi/statium/Platform.jvmAndAndroid.kt
@@ -17,6 +17,9 @@ package eu.europa.ec.eudi.statium
 
 import eu.europa.ec.eudi.statium.misc.Decompress
 import eu.europa.ec.eudi.statium.misc.JvmAndroidDecompress
+import kotlinx.coroutines.Dispatchers
 import kotlin.coroutines.CoroutineContext
+
+internal actual fun platformIoContext(): CoroutineContext = Dispatchers.IO
 
 internal actual fun platformDecompress(context: CoroutineContext): Decompress = JvmAndroidDecompress(context)


### PR DESCRIPTION
- **Removed references to Dispatchers.IO from commonMain and commonTest**
- **Remove JVM-specific code from Types.kt**
- **Remove JVM-specific code from GetStatusTest.kt**
- **Code format**
- **Removed JVM-specific code from ByteArrayAsBase64UrlNoPaddingSerializerTest.kt**
