### PR TITLE
Remove JVM-specific StatusListTokenClaims

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -57,6 +57,7 @@ kotlin {
                 "kotlinx.serialization.ExperimentalSerializationApi",
                 "kotlin.contracts.ExperimentalContracts",
                 "kotlin.io.encoding.ExperimentalEncodingApi",
+                "kotlin.ExperimentalStdlibApi",
             )
         freeCompilerArgs =
             listOf(

--- a/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/Types.kt
+++ b/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/Types.kt
@@ -19,10 +19,12 @@ import eu.europa.ec.eudi.statium.Status.Companion.applicationSpecificRange
 import eu.europa.ec.eudi.statium.Status.Companion.isApplicationSpecific
 import eu.europa.ec.eudi.statium.jose.RFC7519
 import eu.europa.ec.eudi.statium.misc.*
+import kotlinx.datetime.Instant
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.Required
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlin.time.Duration
 
 /**
  * Represents the number of [bits] for a status.
@@ -153,6 +155,18 @@ public data class StatusList(
     }
 }
 
+/**
+ * An [Instant] that will be serialized using [EpocSecondsSerializer]
+ * Can be used for claims like "exp", "iat", "nbf"
+ */
+public typealias InstantAsEpocSeconds = @Contextual Instant
+
+/**
+ * A [Duration] that is represented in JSON
+ * as seconds.
+ */
+public typealias DurationAsSeconds = @Contextual Duration
+
 @Serializable
 @JvmInline
 public value class TimeToLive(public val value: DurationAsSeconds) {
@@ -169,8 +183,8 @@ public value class TimeToLive(public val value: DurationAsSeconds) {
 @Serializable
 public data class StatusListTokenClaims(
     @SerialName(RFC7519.SUBJECT) @Required val subject: String,
-    @SerialName(RFC7519.ISSUED_AT) @Required val issuedAt: InstantAsEpocSeconds,
-    @SerialName(RFC7519.EXPIRATION_TIME) val expirationTime: InstantAsEpocSeconds? = null,
+    @SerialName(RFC7519.ISSUED_AT) @Required @Contextual val issuedAt: InstantAsEpocSeconds,
+    @SerialName(RFC7519.EXPIRATION_TIME) @Contextual val expirationTime: InstantAsEpocSeconds? = null,
     @SerialName(TokenStatusListSpec.TIME_TO_LIVE) val timeToLive: TimeToLive? = null,
     @SerialName(TokenStatusListSpec.STATUS_LIST) val statusList: StatusList,
 ) {

--- a/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/jose/Jwt.kt
+++ b/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/jose/Jwt.kt
@@ -16,7 +16,7 @@
 package eu.europa.ec.eudi.statium.jose
 
 import eu.europa.ec.eudi.statium.misc.Base64UrlNoPadding
-import eu.europa.ec.eudi.statium.misc.JsonIgnoringUnknownKeys
+import eu.europa.ec.eudi.statium.misc.StatiumJson
 import kotlinx.io.Buffer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.io.decodeFromSource
@@ -24,7 +24,7 @@ import kotlinx.serialization.json.io.decodeFromSource
 internal inline fun <reified H, reified P> jwtHeaderAndPayload(jwt: String): Result<Pair<H, P>> =
     runCatching {
         val (headerPart, payloadPart, _) = parts(jwt)
-        with(JsonIgnoringUnknownKeys) {
+        with(StatiumJson) {
             val header = decodeBase64<H>(headerPart)
             val statusList = decodeBase64<P>(payloadPart)
             header to statusList

--- a/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/misc/DurationAsSecondsSerializer.kt
+++ b/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/misc/DurationAsSecondsSerializer.kt
@@ -16,7 +16,6 @@
 package eu.europa.ec.eudi.statium.misc
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -25,18 +24,10 @@ import kotlinx.serialization.encoding.Encoder
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
-/**
- * A [Duration] that is represented in JSON
- * as seconds.
- */
-public typealias DurationAsSeconds =
-    @Serializable(with = DurationAsSecondsSerializer::class)
-    Duration
-
 internal object DurationAsSecondsSerializer : KSerializer<Duration> {
 
     override val descriptor: SerialDescriptor =
-        PrimitiveSerialDescriptor("eu.europa.ec.eudi.statium.misc.DurationAsSeconds", PrimitiveKind.LONG)
+        PrimitiveSerialDescriptor("eu.europa.ec.eudi.statium.misc.DurationAsSecondsSerializer", PrimitiveKind.LONG)
 
     override fun deserialize(decoder: Decoder): Duration = decoder.decodeLong().seconds
 

--- a/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/misc/EpocSecondsSerializer.kt
+++ b/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/misc/EpocSecondsSerializer.kt
@@ -17,20 +17,11 @@ package eu.europa.ec.eudi.statium.misc
 
 import kotlinx.datetime.Instant
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-
-/**
- * An [Instant] that will be serialized using [EpocSecondsSerializer]
- * Can be used for claims like "exp", "iat", "nbf"
- */
-public typealias InstantAsEpocSeconds =
-    @Serializable(with = EpocSecondsSerializer::class)
-    Instant
 
 /**
  * Serializes an [kotlinx.datetime.Instant] as a [Long] representing the [kotlinx.datetime.Instant.epochSeconds]

--- a/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/misc/StatiumJson.kt
+++ b/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/misc/StatiumJson.kt
@@ -16,6 +16,8 @@
 package eu.europa.ec.eudi.statium.misc
 
 import eu.europa.ec.eudi.statium.CompressedByteArray
+import eu.europa.ec.eudi.statium.DurationAsSeconds
+import eu.europa.ec.eudi.statium.InstantAsEpocSeconds
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 
@@ -26,10 +28,15 @@ import kotlinx.serialization.modules.SerializersModule
 public val StatiumJsonSerializersModule: SerializersModule =
     SerializersModule {
         contextual(CompressedByteArray::class, ByteArrayAsBase64UrlNoPaddingSerializer)
+        contextual(InstantAsEpocSeconds::class, EpocSecondsSerializer)
+        contextual(DurationAsSeconds::class, DurationAsSecondsSerializer)
     }
 
-internal val JsonIgnoringUnknownKeys: Json =
+public val StatiumJson: Json =
     Json {
         ignoreUnknownKeys = true
+        encodeDefaults = false
+        explicitNulls = false
+        prettyPrint = false
         serializersModule = StatiumJsonSerializersModule
     }

--- a/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/ReadStatusTestVectors.kt
+++ b/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/ReadStatusTestVectors.kt
@@ -15,7 +15,7 @@
  */
 package eu.europa.ec.eudi.statium
 
-import eu.europa.ec.eudi.statium.misc.JsonIgnoringUnknownKeys
+import eu.europa.ec.eudi.statium.misc.StatiumJson
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -28,7 +28,7 @@ class TestVector(
     @OptIn(ExperimentalStdlibApi::class)
     constructor(expectedStatuses: Map<Int, Int>, statusListJson: String, statusListCborHex: String) : this(
         expectedStatuses.map { (i, s) -> StatusIndex(i) to Status(s.toByte()) }.toMap(),
-        JsonIgnoringUnknownKeys.decodeFromString(StatusList.serializer(), statusListJson),
+        StatiumJson.decodeFromString(StatusList.serializer(), statusListJson),
         statusListCborHex.hexToByteArray(HexFormat.Default),
     )
 }

--- a/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/ReadStatusTestVectors.kt
+++ b/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/ReadStatusTestVectors.kt
@@ -25,7 +25,6 @@ class TestVector(
     val statusList: StatusList,
     val statusListCborBytes: ByteArray,
 ) {
-    @OptIn(ExperimentalStdlibApi::class)
     constructor(expectedStatuses: Map<Int, Int>, statusListJson: String, statusListCborHex: String) : this(
         expectedStatuses.map { (i, s) -> StatusIndex(i) to Status(s.toByte()) }.toMap(),
         StatiumJson.decodeFromString(StatusList.serializer(), statusListJson),

--- a/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/StatusListTokenClaimsTest.kt
+++ b/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/StatusListTokenClaimsTest.kt
@@ -15,7 +15,7 @@
  */
 package eu.europa.ec.eudi.statium
 
-import eu.europa.ec.eudi.statium.misc.JsonIgnoringUnknownKeys
+import eu.europa.ec.eudi.statium.misc.StatiumJson
 import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -25,8 +25,6 @@ import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.seconds
 
 class StatusListTokenClaimsTest {
-
-    private val jsonSupport = JsonIgnoringUnknownKeys
 
     @Test
     fun testCreation() {
@@ -95,7 +93,7 @@ class StatusListTokenClaimsTest {
             statusList = statusList,
         )
 
-        val json = jsonSupport.encodeToString(StatusListTokenClaims.serializer(), claims)
+        val json = StatiumJson.encodeToString(StatusListTokenClaims.serializer(), claims)
 
         // Verify the JSON contains the expected field names and values
         val expectedJson = """{"sub":"https://example.com/issuer","iat":1625097600,"exp":1656633600,"ttl":2592000,"status_list":{"bits":1,"lst":"eNrt3AENwCAMAEGogklACtKQPg9LugC9k_ACvreiogEAAKkeCQAAAAAAAAAAAAAAAAAAAIBylgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXG9IAAAAAAAAAPwsJAAAAAAAAAAAAAAAvhsSAAAAAAAAAAAA7KpLAAAAAAAAAAAAAAAAAAAAAJsLCQAAAAAAAAAAADjelAAAAAAAAAAAKjDMAQAAAACAZC8L2AEb"}}"""
@@ -104,9 +102,10 @@ class StatusListTokenClaimsTest {
 
     @Test
     fun testDeserialization() {
-        val json = """{"sub":"https://example.com/issuer","iat":1625097600,"exp":1656633600,"ttl":2592000,"status_list":{"bits":1,"lst":"eNrt3AENwCAMAEGogklACtKQPg9LugC9k_ACvreiogEAAKkeCQAAAAAAAAAAAAAAAAAAAIBylgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXG9IAAAAAAAAAPwsJAAAAAAAAAAAAAAAvhsSAAAAAAAAAAAA7KpLAAAAAAAAAAAAAAAAAAAAAJsLCQAAAAAAAAAAADjelAAAAAAAAAAAKjDMAQAAAACAZC8L2AEb"}}"""
+        val json =
+            """{"sub":"https://example.com/issuer","iat":1625097600,"exp":1656633600,"ttl":2592000,"status_list":{"bits":1,"lst":"eNrt3AENwCAMAEGogklACtKQPg9LugC9k_ACvreiogEAAKkeCQAAAAAAAAAAAAAAAAAAAIBylgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXG9IAAAAAAAAAPwsJAAAAAAAAAAAAAAAvhsSAAAAAAAAAAAA7KpLAAAAAAAAAAAAAAAAAAAAAJsLCQAAAAAAAAAAADjelAAAAAAAAAAAKjDMAQAAAACAZC8L2AEb"}}"""
 
-        val claims = jsonSupport.decodeFromString(StatusListTokenClaims.serializer(), json)
+        val claims = StatiumJson.decodeFromString(StatusListTokenClaims.serializer(), json)
 
         assertEquals("https://example.com/issuer", claims.subject)
         assertEquals(Instant.fromEpochSeconds(1625097600L), claims.issuedAt)
@@ -131,8 +130,8 @@ class StatusListTokenClaimsTest {
             statusList = statusList,
         )
 
-        val json = jsonSupport.encodeToString(StatusListTokenClaims.serializer(), original)
-        val deserialized = jsonSupport.decodeFromString(StatusListTokenClaims.serializer(), json)
+        val json = StatiumJson.encodeToString(StatusListTokenClaims.serializer(), original)
+        val deserialized = StatiumJson.decodeFromString(StatusListTokenClaims.serializer(), json)
 
         assertEquals(original, deserialized)
     }
@@ -144,24 +143,25 @@ class StatusListTokenClaimsTest {
         val jsonWithoutStatusList = """{"sub":"https://example.com/issuer","iat":1625097600,"exp":1656633600,"ttl":2592000}"""
 
         assertFailsWith<kotlinx.serialization.MissingFieldException> {
-            jsonSupport.decodeFromString(StatusListTokenClaims.serializer(), jsonWithoutSubject)
+            StatiumJson.decodeFromString(StatusListTokenClaims.serializer(), jsonWithoutSubject)
         }
 
         assertFailsWith<kotlinx.serialization.MissingFieldException> {
-            jsonSupport.decodeFromString(StatusListTokenClaims.serializer(), jsonWithoutIssuedAt)
+            StatiumJson.decodeFromString(StatusListTokenClaims.serializer(), jsonWithoutIssuedAt)
         }
 
         assertFailsWith<kotlinx.serialization.MissingFieldException> {
-            jsonSupport.decodeFromString(StatusListTokenClaims.serializer(), jsonWithoutStatusList)
+            StatiumJson.decodeFromString(StatusListTokenClaims.serializer(), jsonWithoutStatusList)
         }
     }
 
     @Test
     fun testDeserializationWithDifferentStatusListBits() {
         // Test with TV2 (2 bits per status)
-        val jsonWithTV2 = """{"sub":"https://example.com/issuer","iat":1625097600,"status_list":{"bits":2,"lst":"eNrt2zENACEQAEEuoaBABP5VIO01fCjIHTMStt9ovGVIAAAAAABAbiEBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEB5WwIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAID0ugQAAAAAAAAAAAAAAAAAQG12SgAAAAAAAAAAAAAAAAAAAAAAAAAAAOCSIQEAAAAAAAAAAAAAAAAAAAAAAAD8ExIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwJEuAQAAAAAAAAAAAAAAAAAAAAAAAMB9SwIAAAAAAAAAAAAAAAAAAACoYUoAAAAAAAAAAAAAAEBqH81gAQw"}}"""
+        val jsonWithTV2 =
+            """{"sub":"https://example.com/issuer","iat":1625097600,"status_list":{"bits":2,"lst":"eNrt2zENACEQAEEuoaBABP5VIO01fCjIHTMStt9ovGVIAAAAAABAbiEBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEB5WwIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAID0ugQAAAAAAAAAAAAAAAAAQG12SgAAAAAAAAAAAAAAAAAAAAAAAAAAAOCSIQEAAAAAAAAAAAAAAAAAAAAAAAD8ExIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwJEuAQAAAAAAAAAAAAAAAAAAAAAAAMB9SwIAAAAAAAAAAAAAAAAAAACoYUoAAAAAAAAAAAAAAEBqH81gAQw"}}"""
 
-        val claims = jsonSupport.decodeFromString(StatusListTokenClaims.serializer(), jsonWithTV2)
+        val claims = StatiumJson.decodeFromString(StatusListTokenClaims.serializer(), jsonWithTV2)
 
         assertEquals("https://example.com/issuer", claims.subject)
         assertEquals(Instant.fromEpochSeconds(1625097600L), claims.issuedAt)
@@ -170,9 +170,10 @@ class StatusListTokenClaimsTest {
 
     @Test
     fun testDeserializationWithOptionalFieldsOmitted() {
-        val jsonWithoutOptionalFields = """{"sub":"https://example.com/issuer","iat":1625097600,"status_list":{"bits":1,"lst":"eNrt3AENwCAMAEGogklACtKQPg9LugC9k_ACvreiogEAAKkeCQAAAAAAAAAAAAAAAAAAAIBylgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXG9IAAAAAAAAAPwsJAAAAAAAAAAAAAAAvhsSAAAAAAAAAAAA7KpLAAAAAAAAAAAAAAAAAAAAAJsLCQAAAAAAAAAAADjelAAAAAAAAAAAKjDMAQAAAACAZC8L2AEb"}}"""
+        val jsonWithoutOptionalFields =
+            """{"sub":"https://example.com/issuer","iat":1625097600,"status_list":{"bits":1,"lst":"eNrt3AENwCAMAEGogklACtKQPg9LugC9k_ACvreiogEAAKkeCQAAAAAAAAAAAAAAAAAAAIBylgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXG9IAAAAAAAAAPwsJAAAAAAAAAAAAAAAvhsSAAAAAAAAAAAA7KpLAAAAAAAAAAAAAAAAAAAAAJsLCQAAAAAAAAAAADjelAAAAAAAAAAAKjDMAQAAAACAZC8L2AEb"}}"""
 
-        val claims = jsonSupport.decodeFromString(StatusListTokenClaims.serializer(), jsonWithoutOptionalFields)
+        val claims = StatiumJson.decodeFromString(StatusListTokenClaims.serializer(), jsonWithoutOptionalFields)
 
         assertEquals("https://example.com/issuer", claims.subject)
         assertEquals(Instant.fromEpochSeconds(1625097600L), claims.issuedAt)

--- a/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/misc/ByteArrayAsBase64UrlNoPaddingSerializerTest.kt
+++ b/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/misc/ByteArrayAsBase64UrlNoPaddingSerializerTest.kt
@@ -26,66 +26,88 @@ import kotlin.test.assertFailsWith
 
 class ByteArrayAsBase64UrlNoPaddingSerializerTest {
 
-    private val json = JsonIgnoringUnknownKeys
-
     @Test
     fun testSerializeEmptyByteArray() {
         val byteArray = ByteArray(0)
-        val serialized = json.encodeToString(ByteArrayAsBase64UrlNoPaddingSerializer, byteArray)
+        val serialized = StatiumJson.encodeToString(ByteArrayAsBase64UrlNoPaddingSerializer, byteArray)
         assertEquals("\"\"", serialized, "Serializing an empty byte array should result in an empty string")
     }
 
     @Test
     fun testDeserializeEmptyString() {
         val serialized = "\"\""
-        val deserialized = json.decodeFromString(ByteArrayAsBase64UrlNoPaddingSerializer, serialized)
-        assertContentEquals(ByteArray(0), deserialized, "Deserializing an empty string should result in an empty byte array")
+        val deserialized = StatiumJson.decodeFromString(ByteArrayAsBase64UrlNoPaddingSerializer, serialized)
+        assertContentEquals(
+            ByteArray(0),
+            deserialized,
+            "Deserializing an empty string should result in an empty byte array",
+        )
     }
 
     @Test
     fun testSerializeSimpleByteArray() {
         val byteArray = "Hello, World!".encodeToByteArray()
-        val serialized = json.encodeToString(ByteArrayAsBase64UrlNoPaddingSerializer, byteArray)
-        assertEquals("\"SGVsbG8sIFdvcmxkIQ\"", serialized, "Serializing 'Hello, World!' bytes should result in 'SGVsbG8sIFdvcmxkIQ'")
+        val serialized = StatiumJson.encodeToString(ByteArrayAsBase64UrlNoPaddingSerializer, byteArray)
+        assertEquals(
+            "\"SGVsbG8sIFdvcmxkIQ\"",
+            serialized,
+            "Serializing 'Hello, World!' bytes should result in 'SGVsbG8sIFdvcmxkIQ'",
+        )
     }
 
     @Test
     fun testDeserializeSimpleString() {
         val serialized = "\"SGVsbG8sIFdvcmxkIQ\""
-        val deserialized = json.decodeFromString(ByteArrayAsBase64UrlNoPaddingSerializer, serialized)
+        val deserialized = StatiumJson.decodeFromString(ByteArrayAsBase64UrlNoPaddingSerializer, serialized)
         val expected = "Hello, World!".encodeToByteArray()
-        assertContentEquals(expected, deserialized, "Deserializing 'SGVsbG8sIFdvcmxkIQ' should result in 'Hello, World!' bytes")
+        assertContentEquals(
+            expected,
+            deserialized,
+            "Deserializing 'SGVsbG8sIFdvcmxkIQ' should result in 'Hello, World!' bytes",
+        )
     }
 
     @Test
     fun testSerializeWithSpecialCharacters() {
         val byteArray = "Special characters: !@#$%^&*()_+".encodeToByteArray()
-        val serialized = json.encodeToString(ByteArrayAsBase64UrlNoPaddingSerializer, byteArray)
-        val deserialized = json.decodeFromString(ByteArrayAsBase64UrlNoPaddingSerializer, serialized)
-        assertContentEquals(byteArray, deserialized, "Serializing and then deserializing should result in the original byte array")
+        val serialized = StatiumJson.encodeToString(ByteArrayAsBase64UrlNoPaddingSerializer, byteArray)
+        val deserialized = StatiumJson.decodeFromString(ByteArrayAsBase64UrlNoPaddingSerializer, serialized)
+        assertContentEquals(
+            byteArray,
+            deserialized,
+            "Serializing and then deserializing should result in the original byte array",
+        )
     }
 
     @Test
     fun testSerializeWithNonAsciiCharacters() {
         val byteArray = "Non-ASCII characters: äöüßÄÖÜ€".encodeToByteArray()
-        val serialized = json.encodeToString(ByteArrayAsBase64UrlNoPaddingSerializer, byteArray)
-        val deserialized = json.decodeFromString(ByteArrayAsBase64UrlNoPaddingSerializer, serialized)
-        assertContentEquals(byteArray, deserialized, "Serializing and then deserializing should result in the original byte array")
+        val serialized = StatiumJson.encodeToString(ByteArrayAsBase64UrlNoPaddingSerializer, byteArray)
+        val deserialized = StatiumJson.decodeFromString(ByteArrayAsBase64UrlNoPaddingSerializer, serialized)
+        assertContentEquals(
+            byteArray,
+            deserialized,
+            "Serializing and then deserializing should result in the original byte array",
+        )
     }
 
     @Test
     fun testSerializeBinaryData() {
         val byteArray = ByteArray(256) { it.toByte() }
-        val serialized = json.encodeToString(ByteArrayAsBase64UrlNoPaddingSerializer, byteArray)
-        val deserialized = json.decodeFromString(ByteArrayAsBase64UrlNoPaddingSerializer, serialized)
-        assertContentEquals(byteArray, deserialized, "Serializing and then deserializing binary data should result in the original byte array")
+        val serialized = StatiumJson.encodeToString(ByteArrayAsBase64UrlNoPaddingSerializer, byteArray)
+        val deserialized = StatiumJson.decodeFromString(ByteArrayAsBase64UrlNoPaddingSerializer, serialized)
+        assertContentEquals(
+            byteArray,
+            deserialized,
+            "Serializing and then deserializing binary data should result in the original byte array",
+        )
     }
 
     @Test
     fun testDeserializeInvalidBase64() {
         val invalidBase64 = "\"This is not valid Base64!\""
         assertFailsWith<SerializationException> {
-            json.decodeFromString(ByteArrayAsBase64UrlNoPaddingSerializer, invalidBase64)
+            StatiumJson.decodeFromString(ByteArrayAsBase64UrlNoPaddingSerializer, invalidBase64)
         }
     }
 
@@ -102,9 +124,13 @@ class ByteArrayAsBase64UrlNoPaddingSerializerTest {
         )
 
         for (testCase in testCases) {
-            val serialized = json.encodeToString(ByteArrayAsBase64UrlNoPaddingSerializer, testCase)
-            val deserialized = json.decodeFromString(ByteArrayAsBase64UrlNoPaddingSerializer, serialized)
-            assertContentEquals(testCase, deserialized, "Round trip serialization and deserialization should result in the original byte array")
+            val serialized = StatiumJson.encodeToString(ByteArrayAsBase64UrlNoPaddingSerializer, testCase)
+            val deserialized = StatiumJson.decodeFromString(ByteArrayAsBase64UrlNoPaddingSerializer, serialized)
+            assertContentEquals(
+                testCase,
+                deserialized,
+                "Round trip serialization and deserialization should result in the original byte array",
+            )
         }
     }
 
@@ -115,14 +141,14 @@ class ByteArrayAsBase64UrlNoPaddingSerializerTest {
         class TestData(val data: CompressedByteArray)
 
         val original = TestData("Hello, World!".encodeToByteArray())
-        val serialized = json.encodeToString(serializer<TestData>(), original)
+        val serialized = StatiumJson.encodeToString(serializer<TestData>(), original)
 
         // The serialized string should contain the Base64URL-encoded bytes
         val expected = "{\"data\":\"SGVsbG8sIFdvcmxkIQ\"}"
         assertEquals(expected, serialized, "The typealias should serialize correctly")
 
         // Deserialize and verify
-        val deserialized = json.decodeFromString<TestData>(serialized)
+        val deserialized = StatiumJson.decodeFromString<TestData>(serialized)
         assertContentEquals(original.data, deserialized.data, "The typealias should deserialize correctly")
     }
 }


### PR DESCRIPTION
This PR removes from the following classes the JSON-specific serialization options, making them serialized "contextual"

- `InstantAsEpocSeconds`
- `DurationAsSeconds`
- `TimeToLive`
- `StatusListTokenClaims`

To use them with JSON format, the `StatiumJsonSerializersModule` & `StatiumJson` were also made public 
