### PR TITLE
Public API improvements

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ android.minSdk=26
 # Publishing settings
 namespace=eu.europa.ec.eudi.status
 group=eu.europa.ec.eudi
-version=0.1.3-SNAPSHOT
+version=0.2.0-SNAPSHOT
 
 # Maven Publish Plugin settings
 SONATYPE_HOST=S01

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -10,39 +10,16 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.maven.publish)
-    alias(libs.plugins.spotless)
-    alias(libs.plugins.dependency.check)
     alias(libs.plugins.kover)
+    alias(libs.plugins.spotless)
     alias(libs.plugins.dokka)
+    alias(libs.plugins.maven.publish)
+    alias(libs.plugins.dependency.check)
 }
 
 repositories {
     mavenCentral()
     google()
-}
-
-spotless {
-    kotlin {
-        target("**/*.kt")
-        targetExclude("**/build/**/*.kt")
-        ktlint(libs.versions.ktlint.get())
-            .editorConfigOverride(
-                mapOf(
-                    "ktlint_standard_filename" to "disabled",
-                    "ktlint_standard_no-wildcard-imports" to "disabled",
-                ),
-            )
-        trimTrailingWhitespace()
-        licenseHeaderFile("../FileHeader.txt")
-        endWithNewline()
-    }
-    kotlinGradle {
-        target("**/*.gradle.kts")
-        ktlint(libs.versions.ktlint.get())
-        trimTrailingWhitespace()
-        endWithNewline()
-    }
 }
 
 kotlin {
@@ -170,33 +147,26 @@ android {
     }
 }
 
-dependencyCheck {
-    formats = listOf("XML", "HTML")
-    nvd.apiKey = System.getenv("NVD_API_KEY") ?: properties["nvdApiKey"]?.toString() ?: ""
-    nvd.delay = 10000
-    nvd.maxRetryCount = 2
-}
-
-mavenPublishing {
-    configure(
-        KotlinMultiplatform(
-            javadocJar = JavadocJar.Dokka(tasks.dokkaHtml.name),
-            sourcesJar = true,
-            androidVariantsToPublish = listOf("release"),
-        ),
-    )
-
-    coordinates(
-        groupId = group.toString(),
-        artifactId = "eudi-lib-kmp-statium",
-        version = version.toString(),
-    )
-
-    pom {
-        ciManagement {
-            system = "github"
-            url = "${project.properties["POM_SCM_URL"]}/actions"
-        }
+spotless {
+    kotlin {
+        target("**/*.kt")
+        targetExclude("**/build/**/*.kt")
+        ktlint(libs.versions.ktlint.get())
+            .editorConfigOverride(
+                mapOf(
+                    "ktlint_standard_filename" to "disabled",
+                    "ktlint_standard_no-wildcard-imports" to "disabled",
+                ),
+            )
+        trimTrailingWhitespace()
+        licenseHeaderFile("../FileHeader.txt")
+        endWithNewline()
+    }
+    kotlinGradle {
+        target("**/*.gradle.kts")
+        ktlint(libs.versions.ktlint.get())
+        trimTrailingWhitespace()
+        endWithNewline()
     }
 }
 
@@ -228,4 +198,34 @@ tasks.withType<DokkaTask>().configureEach {
                 }
         }
     }
+}
+
+mavenPublishing {
+    configure(
+        KotlinMultiplatform(
+            javadocJar = JavadocJar.Dokka(tasks.dokkaHtml.name),
+            sourcesJar = true,
+            androidVariantsToPublish = listOf("release"),
+        ),
+    )
+
+    coordinates(
+        groupId = group.toString(),
+        artifactId = "eudi-lib-kmp-statium",
+        version = version.toString(),
+    )
+
+    pom {
+        ciManagement {
+            system = "github"
+            url = "${project.properties["POM_SCM_URL"]}/actions"
+        }
+    }
+}
+
+dependencyCheck {
+    formats = listOf("XML", "HTML")
+    nvd.apiKey = System.getenv("NVD_API_KEY") ?: properties["nvdApiKey"]?.toString() ?: ""
+    nvd.delay = 10000
+    nvd.maxRetryCount = 2
 }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -31,7 +31,6 @@ kotlin {
         optIn =
             listOf(
                 "kotlinx.serialization.ExperimentalSerializationApi",
-                "kotlin.contracts.ExperimentalContracts",
                 "kotlin.io.encoding.ExperimentalEncodingApi",
                 "kotlin.ExperimentalStdlibApi",
             )

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -60,6 +60,7 @@ kotlin {
     // Set up targets
     @OptIn(ExperimentalKotlinGradlePluginApi::class)
     applyDefaultHierarchyTemplate {
+
         // create a new group that depends on `common`
         common {
             // Define group name without `Main` as suffix
@@ -95,28 +96,10 @@ kotlin {
             }
         }
 
-        @Suppress("unused")
-        val jvmAndAndroidMain by getting {
-            dependencies { }
-        }
-
-        @Suppress("unused")
-        val jvmAndAndroidTest by getting {
-            dependencies { }
-        }
-
-        jvmMain {
-            dependencies { }
-        }
-
         jvmTest {
             dependencies {
                 implementation(libs.ktor.client.java)
             }
-        }
-
-        androidMain {
-            dependencies { }
         }
 
         androidUnitTest {

--- a/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/GetStatus.kt
+++ b/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/GetStatus.kt
@@ -21,21 +21,38 @@ import kotlinx.datetime.Instant
 /**
  * Allows the caller to get the status of a [`status_list`][StatusReference],
  * found in a referenced token.
- *
  */
 public fun interface GetStatus {
     /**
-     * Gets the status of the [StatusReference]
-     * A [time point][at] can be specified
+     * Gets the status of the [StatusReference], optionally specifying a [time point][at].
+     *
+     * Note: there are some privacy preserving considerations if [at] is provided, since
+     * it can cause a time point information to be included to the query passed
+     * to the Status list token Provider.
+     *
+     * It is recommended to use [currentStatus]
+     *
+     * @receiver The reference to the status, found in a Referenced Token
+     * @param at the time point to check the status.
+     * @return the status read
      */
     public suspend fun StatusReference.status(at: Instant?): Result<Status>
+
+    /**
+     * Gets the status of the [StatusReference] at present time
+     * @receiver The reference to the status, found in a Referenced Token
+     * @return the status read
+     * */
+    public suspend fun StatusReference.currentStatus(): Result<Status> = status(at = null)
 
     public companion object {
 
         /**
          * Factory method for creating an instance of [GetStatus],
-         * given a [way][getStatusListToken] to fetch the Status List token
-         * and a [way][Decompress] to decompress its content
+         *
+         * @param getStatusListToken a way to fetch the Status List token
+         * @param decompress a way to decompress the status list contents. If not provided defaults to [platformDecompress]
+         * @return an instance of [GetStatus]
          */
         public operator fun invoke(
             getStatusListToken: GetStatusListToken,

--- a/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/TokenStatusListSpec.kt
+++ b/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/TokenStatusListSpec.kt
@@ -31,12 +31,12 @@ public object TokenStatusListSpec {
     public const val TIME_TO_LIVE: String = "ttl"
     public const val TIME: String = "time"
 
-    public const val STATUS_VALID: Byte = 0x00
-    public const val STATUS_INVALID: Byte = 0x01
-    public const val STATUS_SUSPENDED: Byte = 0x02
-    public const val STATUS_APPLICATION_SPECIFIC: Byte = 0x03
-    public const val STATUS_APPLICATION_SPECIFIC_RANGE_START: Byte = 0x0B
-    public const val STATUS_APPLICATION_SPECIFIC_RANGE_END: Byte = 0x0F
+    public const val STATUS_VALID: UByte = 0x00u
+    public const val STATUS_INVALID: UByte = 0x01u
+    public const val STATUS_SUSPENDED: UByte = 0x02u
+    public const val STATUS_APPLICATION_SPECIFIC: UByte = 0x03u
+    public const val STATUS_APPLICATION_SPECIFIC_RANGE_START: UByte = 0x0Bu
+    public const val STATUS_APPLICATION_SPECIFIC_RANGE_END: UByte = 0x0Fu
 
     public const val MEDIA_SUBTYPE_STATUS_LIST_JWT: String = "statuslist+jwt"
     public const val MEDIA_TYPE_APPLICATION_STATUS_LIST_JWT: String = "application/$MEDIA_SUBTYPE_STATUS_LIST_JWT"

--- a/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/Types.kt
+++ b/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/Types.kt
@@ -183,7 +183,7 @@ public typealias DurationAsSeconds = @Contextual Duration
  */
 @Serializable
 @JvmInline
-public value class TimeToLive(public val value: DurationAsSeconds) {
+public value class PositiveDurationAsSeconds(public val value: DurationAsSeconds) {
     init {
         require(value.isPositive()) { "Time to live value must be positive" }
     }
@@ -209,7 +209,7 @@ public constructor(
     @SerialName(RFC7519.SUBJECT) @Required val subject: String,
     @SerialName(RFC7519.ISSUED_AT) @Required @Contextual val issuedAt: InstantAsEpocSeconds,
     @SerialName(RFC7519.EXPIRATION_TIME) @Contextual val expirationTime: InstantAsEpocSeconds? = null,
-    @SerialName(TokenStatusListSpec.TIME_TO_LIVE) val timeToLive: TimeToLive? = null,
+    @SerialName(TokenStatusListSpec.TIME_TO_LIVE) val timeToLive: PositiveDurationAsSeconds? = null,
     @SerialName(TokenStatusListSpec.STATUS_LIST) val statusList: StatusList,
 ) {
     init {

--- a/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/Types.kt
+++ b/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/Types.kt
@@ -52,11 +52,9 @@ public enum class BitsPerStatus(public val bits: Int) {
         /**
          * Attempts to get aa [BitsPerStatus], given the number of [bits]
          * @param bits number of bits
-         * @return the [eu.europa.ec.eudi.statium.BitsPerStatus] or null
+         * @return the [BitsPerStatus] or null
          */
-        public fun forBits(bits: Int): BitsPerStatus? {
-            return BitsPerStatus.entries.find { it.bits == bits }
-        }
+        public fun fromBitsOrNull(bits: Int): BitsPerStatus? = BitsPerStatus.entries.find { it.bits == bits }
     }
 }
 

--- a/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/misc/BitsPerStatusSerializer.kt
+++ b/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/misc/BitsPerStatusSerializer.kt
@@ -35,7 +35,7 @@ internal object BitsPerStatusSerializer : KSerializer<BitsPerStatus> {
 
     override fun deserialize(decoder: Decoder): BitsPerStatus {
         val bits = decoder.decodeInt()
-        return BitsPerStatus.forBits(bits)
+        return BitsPerStatus.fromBitsOrNull(bits)
             ?: throw SerializationException("Invalid bits value: $bits")
     }
 }

--- a/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/misc/BitsPerStatusSerializer.kt
+++ b/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/misc/BitsPerStatusSerializer.kt
@@ -27,7 +27,7 @@ import kotlinx.serialization.encoding.Encoder
 internal object BitsPerStatusSerializer : KSerializer<BitsPerStatus> {
 
     override val descriptor: SerialDescriptor
-        get() = PrimitiveSerialDescriptor("eu.europa.ec.eudi.statium.misc.BitsPerStatus", PrimitiveKind.INT)
+        get() = PrimitiveSerialDescriptor("eu.europa.ec.eudi.statium.misc.BitsPerStatusSerializer", PrimitiveKind.INT)
 
     override fun serialize(encoder: Encoder, value: BitsPerStatus) {
         encoder.encodeInt(value.bits)
@@ -36,6 +36,6 @@ internal object BitsPerStatusSerializer : KSerializer<BitsPerStatus> {
     override fun deserialize(decoder: Decoder): BitsPerStatus {
         val bits = decoder.decodeInt()
         return BitsPerStatus.forBits(bits)
-            ?: throw SerializationException("Unknown BitsPerStatus value: $bits")
+            ?: throw SerializationException("Invalid bits value: $bits")
     }
 }

--- a/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/misc/DurationAsSecondsSerializer.kt
+++ b/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/misc/DurationAsSecondsSerializer.kt
@@ -24,6 +24,9 @@ import kotlinx.serialization.encoding.Encoder
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
+/**
+ * Serializes a [Duration] as a [Long] representing the [Duration.Companion.seconds]
+ */
 internal object DurationAsSecondsSerializer : KSerializer<Duration> {
 
     override val descriptor: SerialDescriptor =

--- a/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/misc/EpocSecondsSerializer.kt
+++ b/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/misc/EpocSecondsSerializer.kt
@@ -24,11 +24,11 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
 /**
- * Serializes an [kotlinx.datetime.Instant] as a [Long] representing the [kotlinx.datetime.Instant.epochSeconds]
+ * Serializes an [Instant] as a [Long] representing the [kotlinx.datetime.Instant.epochSeconds]
  */
 internal object EpocSecondsSerializer : KSerializer<Instant> {
     override val descriptor: SerialDescriptor =
-        PrimitiveSerialDescriptor("eu.europa.ec.eudi.statium.misc.EpocSeconds", PrimitiveKind.LONG)
+        PrimitiveSerialDescriptor("eu.europa.ec.eudi.statium.misc.EpocSecondsSerializer", PrimitiveKind.LONG)
 
     override fun deserialize(decoder: Decoder): Instant = Instant.fromEpochSeconds(decoder.decodeLong())
 

--- a/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/misc/StatiumJson.kt
+++ b/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/misc/StatiumJson.kt
@@ -24,6 +24,8 @@ import kotlinx.serialization.modules.SerializersModule
 /**
  * [SerializersModule] for JSON format. Defines that
  * - A [CompressedByteArray] is serialized via [ByteArrayAsBase64UrlNoPaddingSerializer]
+ * - An [InstantAsEpocSeconds] is serialized via [EpocSecondsSerializer]
+ * - A [DurationAsSeconds] is serialized via [DurationAsSeconds]
  */
 public val StatiumJsonSerializersModule: SerializersModule =
     SerializersModule {
@@ -32,6 +34,13 @@ public val StatiumJsonSerializersModule: SerializersModule =
         contextual(DurationAsSeconds::class, DurationAsSecondsSerializer)
     }
 
+/**
+ * An instance of [Json] that
+ * - uses [StatiumJsonSerializersModule]
+ * - ignores unknown keys
+ * - doesn't encode default values
+ * - doesn't use explicit nulls
+ */
 public val StatiumJson: Json =
     Json {
         ignoreUnknownKeys = true

--- a/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/PositiveDurationAsSecondsTest.kt
+++ b/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/PositiveDurationAsSecondsTest.kt
@@ -20,12 +20,12 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.time.Duration.Companion.seconds
 
-class TimeToLiveTest {
+class PositiveDurationAsSecondsTest {
 
     @Test
     fun testCreationWithPositiveValue() {
         val duration = 60.seconds
-        val timeToLive = TimeToLive(duration)
+        val timeToLive = PositiveDurationAsSeconds(duration)
         assertEquals(duration, timeToLive.value)
     }
 
@@ -33,7 +33,7 @@ class TimeToLiveTest {
     fun testCreationWithNegativeValueFails() {
         val duration = (-60).seconds
         assertFailsWith<IllegalArgumentException> {
-            TimeToLive(duration)
+            PositiveDurationAsSeconds(duration)
         }
     }
 
@@ -41,14 +41,14 @@ class TimeToLiveTest {
     fun testCreationWithZeroValueFails() {
         val duration = 0.seconds
         assertFailsWith<IllegalArgumentException> {
-            TimeToLive(duration)
+            PositiveDurationAsSeconds(duration)
         }
     }
 
     @Test
     fun testToString() {
         val duration = 120.seconds
-        val timeToLive = TimeToLive(duration)
+        val timeToLive = PositiveDurationAsSeconds(duration)
         assertEquals(duration.toString(), timeToLive.toString())
     }
 }

--- a/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/ReadStatusTest.kt
+++ b/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/ReadStatusTest.kt
@@ -174,7 +174,7 @@ class ReadStatusTest {
     }
 
     internal fun assertEquals(expected: Int, actual: Status?) {
-        assertEquals(Status(expected.toByte()), actual)
+        assertEquals(Status(expected.toUByte()), actual)
     }
 }
 

--- a/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/ReadStatusTestVectors.kt
+++ b/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/ReadStatusTestVectors.kt
@@ -26,7 +26,7 @@ class TestVector(
     val statusListCborBytes: ByteArray,
 ) {
     constructor(expectedStatuses: Map<Int, Int>, statusListJson: String, statusListCborHex: String) : this(
-        expectedStatuses.map { (i, s) -> StatusIndex(i) to Status(s.toByte()) }.toMap(),
+        expectedStatuses.map { (i, s) -> StatusIndex(i) to Status(s.toUByte()) }.toMap(),
         StatiumJson.decodeFromString(StatusList.serializer(), statusListJson),
         statusListCborHex.hexToByteArray(HexFormat.Default),
     )

--- a/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/StatusListTokenClaimsTest.kt
+++ b/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/StatusListTokenClaimsTest.kt
@@ -31,7 +31,7 @@ class StatusListTokenClaimsTest {
         val subject = "https://example.com/issuer"
         val issuedAt = Instant.fromEpochSeconds(1625097600L) // 2021-07-01T00:00:00Z
         val expirationTime = Instant.fromEpochSeconds(1656633600L) // 2022-07-01T00:00:00Z
-        val timeToLive = TimeToLive(30.days)
+        val timeToLive = PositiveDurationAsSeconds(30.days)
         val statusList = TestVectors.TV1.statusList
 
         val claims = StatusListTokenClaims(
@@ -82,7 +82,7 @@ class StatusListTokenClaimsTest {
         val subject = "https://example.com/issuer"
         val issuedAt = Instant.fromEpochSeconds(1625097600L) // 2021-07-01T00:00:00Z
         val expirationTime = Instant.fromEpochSeconds(1656633600L) // 2022-07-01T00:00:00Z
-        val timeToLive = TimeToLive(30.days)
+        val timeToLive = PositiveDurationAsSeconds(30.days)
         val statusList = TestVectors.TV1.statusList
 
         val claims = StatusListTokenClaims(
@@ -110,7 +110,7 @@ class StatusListTokenClaimsTest {
         assertEquals("https://example.com/issuer", claims.subject)
         assertEquals(Instant.fromEpochSeconds(1625097600L), claims.issuedAt)
         assertEquals(Instant.fromEpochSeconds(1656633600L), claims.expirationTime)
-        assertEquals(TimeToLive(2592000.seconds), claims.timeToLive)
+        assertEquals(PositiveDurationAsSeconds(2592000.seconds), claims.timeToLive)
         assertEquals(TestVectors.TV1.statusList, claims.statusList)
     }
 
@@ -119,7 +119,7 @@ class StatusListTokenClaimsTest {
         val subject = "https://example.com/issuer"
         val issuedAt = Instant.fromEpochSeconds(1625097600L)
         val expirationTime = Instant.fromEpochSeconds(1656633600L)
-        val timeToLive = TimeToLive(30.days)
+        val timeToLive = PositiveDurationAsSeconds(30.days)
         val statusList = TestVectors.TV1.statusList
 
         val original = StatusListTokenClaims(

--- a/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/StatusListTokenValidationsTest.kt
+++ b/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/StatusListTokenValidationsTest.kt
@@ -163,7 +163,7 @@ class StatusListTokenValidationsTest : StatusListTokenValidations {
         subject: String = this.subject,
         issuedAt: Instant = now,
         expirationTime: Instant? = null,
-        timeToLive: TimeToLive? = null,
+        timeToLive: PositiveDurationAsSeconds? = null,
     ): StatusListTokenClaims =
         StatusListTokenClaims(
             subject = subject,

--- a/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/StatusTest.kt
+++ b/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/StatusTest.kt
@@ -27,7 +27,7 @@ class StatusTest {
      * Generates a random byte that satisfies Status.isApplicationSpecific()
      * This will either return 0x03 or a value in the range 0x0B..0x0F
      */
-    private fun generateRandomApplicationSpecificByte(): Byte {
+    private fun generateRandomApplicationSpecificByte(): UByte {
         return if (Random.nextBoolean()) {
             // Return STATUS_APPLICATION_SPECIFIC (0x03)
             TokenStatusListSpec.STATUS_APPLICATION_SPECIFIC
@@ -35,7 +35,7 @@ class StatusTest {
             // Return a random value in the application specific range (0x0B..0x0F)
             val rangeStart = TokenStatusListSpec.STATUS_APPLICATION_SPECIFIC_RANGE_START.toInt()
             val rangeEnd = TokenStatusListSpec.STATUS_APPLICATION_SPECIFIC_RANGE_END.toInt()
-            Random.nextInt(rangeStart, rangeEnd + 1).toByte()
+            Random.nextInt(rangeStart, rangeEnd + 1).toUByte()
         }
     }
 
@@ -65,8 +65,8 @@ class StatusTest {
 
     @Test
     fun testInvokeApplicationSpecificHex3() {
-        val status = Status(0x3)
-        assertEquals(Status.ApplicationSpecific(0x3), status)
+        val status = Status(0x3u)
+        assertEquals(Status.ApplicationSpecific(0x3u), status)
     }
 
     @Test
@@ -80,36 +80,36 @@ class StatusTest {
 
     @Test
     fun testInvokeReserved() {
-        val reservedValue: Byte = 0x04
+        val reservedValue: UByte = 0x04u
         val status = Status(reservedValue)
         assertEquals(Status.Reserved(reservedValue), status)
     }
 
     @Test
     fun testToByteValid() {
-        assertEquals(TokenStatusListSpec.STATUS_VALID, Status.Valid.toByte())
+        assertEquals(TokenStatusListSpec.STATUS_VALID, Status.Valid.toUByte())
     }
 
     @Test
     fun testToByteInvalid() {
-        assertEquals(TokenStatusListSpec.STATUS_INVALID, Status.Invalid.toByte())
+        assertEquals(TokenStatusListSpec.STATUS_INVALID, Status.Invalid.toUByte())
     }
 
     @Test
     fun testToByteSuspended() {
-        assertEquals(TokenStatusListSpec.STATUS_SUSPENDED, Status.Suspended.toByte())
+        assertEquals(TokenStatusListSpec.STATUS_SUSPENDED, Status.Suspended.toUByte())
     }
 
     @Test
     fun testToByteApplicationSpecific() {
         val value = TokenStatusListSpec.STATUS_APPLICATION_SPECIFIC
-        assertEquals(value, Status.ApplicationSpecific(value).toByte())
+        assertEquals(value, Status.ApplicationSpecific(value).toUByte())
     }
 
     @Test
     fun testToByteReserved() {
-        val value: Byte = 0x04
-        assertEquals(value, Status.Reserved(value).toByte())
+        val value: UByte = 0x04u
+        assertEquals(value, Status.Reserved(value).toUByte())
     }
 
     @Test
@@ -120,9 +120,9 @@ class StatusTest {
         // Test values in the application specific range (0x0B..0x0F)
         assertTrue(Status.isApplicationSpecific(TokenStatusListSpec.STATUS_APPLICATION_SPECIFIC_RANGE_START))
         assertTrue(Status.isApplicationSpecific(TokenStatusListSpec.STATUS_APPLICATION_SPECIFIC_RANGE_END))
-        assertTrue(Status.isApplicationSpecific(0x0C.toByte()))
-        assertTrue(Status.isApplicationSpecific(0x0D.toByte()))
-        assertTrue(Status.isApplicationSpecific(0x0E.toByte()))
+        assertTrue(Status.isApplicationSpecific(0x0Cu))
+        assertTrue(Status.isApplicationSpecific(0x0Du))
+        assertTrue(Status.isApplicationSpecific(0x0Eu))
 
         // Test random application-specific values
         repeat(10) {
@@ -142,56 +142,8 @@ class StatusTest {
         assertFalse(Status.isApplicationSpecific(TokenStatusListSpec.STATUS_SUSPENDED))
 
         // Test values outside the application specific range
-        assertFalse(Status.isApplicationSpecific(0x04.toByte()))
-        assertFalse(Status.isApplicationSpecific(0x0A.toByte()))
-        assertFalse(Status.isApplicationSpecific(0x10.toByte()))
-    }
-
-    @Test
-    fun testIsAvailableFor() {
-        // Valid and Invalid can be represented by any BitsPerStatus
-        assertTrue(Status.Valid.isAvailableFor(BitsPerStatus.One))
-        assertTrue(Status.Valid.isAvailableFor(BitsPerStatus.Two))
-        assertTrue(Status.Valid.isAvailableFor(BitsPerStatus.Four))
-        assertTrue(Status.Valid.isAvailableFor(BitsPerStatus.Eight))
-
-        assertTrue(Status.Invalid.isAvailableFor(BitsPerStatus.One))
-        assertTrue(Status.Invalid.isAvailableFor(BitsPerStatus.Two))
-        assertTrue(Status.Invalid.isAvailableFor(BitsPerStatus.Four))
-        assertTrue(Status.Invalid.isAvailableFor(BitsPerStatus.Eight))
-
-        // Suspended (0x02) cannot be represented with BitsPerStatus.One
-        assertFalse(Status.Suspended.isAvailableFor(BitsPerStatus.One))
-        assertTrue(Status.Suspended.isAvailableFor(BitsPerStatus.Two))
-        assertTrue(Status.Suspended.isAvailableFor(BitsPerStatus.Four))
-        assertTrue(Status.Suspended.isAvailableFor(BitsPerStatus.Eight))
-
-        // ApplicationSpecific (0x03) cannot be represented with BitsPerStatus.One
-        val appSpecific = Status.ApplicationSpecific(TokenStatusListSpec.STATUS_APPLICATION_SPECIFIC)
-        assertFalse(appSpecific.isAvailableFor(BitsPerStatus.One))
-        assertTrue(appSpecific.isAvailableFor(BitsPerStatus.Two))
-        assertTrue(appSpecific.isAvailableFor(BitsPerStatus.Four))
-        assertTrue(appSpecific.isAvailableFor(BitsPerStatus.Eight))
-
-        // ApplicationSpecific in range (0x0B-0x0F) cannot be represented with BitsPerStatus.One or BitsPerStatus.Two
-        val appSpecificRange = Status.ApplicationSpecific(TokenStatusListSpec.STATUS_APPLICATION_SPECIFIC_RANGE_START)
-        assertFalse(appSpecificRange.isAvailableFor(BitsPerStatus.One))
-        assertFalse(appSpecificRange.isAvailableFor(BitsPerStatus.Two))
-        assertTrue(appSpecificRange.isAvailableFor(BitsPerStatus.Four))
-        assertTrue(appSpecificRange.isAvailableFor(BitsPerStatus.Eight))
-
-        // Reserved (0x04) cannot be represented with BitsPerStatus.One
-        val reserved = Status.Reserved(0x04.toByte())
-        assertFalse(reserved.isAvailableFor(BitsPerStatus.One))
-        assertFalse(reserved.isAvailableFor(BitsPerStatus.Two))
-        assertTrue(reserved.isAvailableFor(BitsPerStatus.Four))
-        assertTrue(reserved.isAvailableFor(BitsPerStatus.Eight))
-
-        // Reserved (0x10) cannot be represented with BitsPerStatus.One, BitsPerStatus.Two, or BitsPerStatus.Four
-        val reservedHigher = Status.Reserved(0x10.toByte())
-        assertFalse(reservedHigher.isAvailableFor(BitsPerStatus.One))
-        assertFalse(reservedHigher.isAvailableFor(BitsPerStatus.Two))
-        assertFalse(reservedHigher.isAvailableFor(BitsPerStatus.Four))
-        assertTrue(reservedHigher.isAvailableFor(BitsPerStatus.Eight))
+        assertFalse(Status.isApplicationSpecific(0x04u))
+        assertFalse(Status.isApplicationSpecific(0x0Au))
+        assertFalse(Status.isApplicationSpecific(0x10u))
     }
 }

--- a/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/misc/BitsPerStatusSerializerTest.kt
+++ b/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/misc/BitsPerStatusSerializerTest.kt
@@ -63,7 +63,7 @@ class BitsPerStatusSerializerTest {
                 Json.Default.decodeFromString<BitsPerStatus>(invalidValue)
             }
             // Verify the exception has the expected message
-            assertTrue(exception.message?.contains("Unknown BitsPerStatus value") == true)
+            assertTrue(exception.message?.contains("Invalid bits value") == true)
         }
     }
 }


### PR DESCRIPTION
This PR tries to intents to improve the public API

- `Status` value is expressed as `UByte` instead of `Byte`  
- Renamed value class `TimeToLive` to `PositiveDurationAsSeconds`
- Better documentation

Some minor breaking changes to the public API are introduced