### PR TITLE
Introduce allowed clock skew to status list token validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ val getStatusListToken: GetStatusListToken = GetStatusListToken.usingJwt(
             // Configure your HTTP client here
         }
     },
-    verifyStatusListTokenSignature = VerifyStatusListTokenSignature.Ignore // Not for production
+    verifyStatusListTokenSignature = VerifyStatusListTokenSignature.Ignore, // Not for production
+    allowedClockSkew = 5.minutes // Allow 5 minutes of clock skew (requires import: kotlin.time.Duration.Companion.minutes)
 )
 
 // Use the GetStatusListToken instance to fetch a status list token
@@ -121,7 +122,7 @@ println("Status list token claims: $claims")
 > ecosystems define their own processing rules. For this reason, you need to provide an implementation
 > of [VerifyStatusListTokenSignature](lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/VerifyStatusListTokenSignature.kt).
 > This will be used to verify the signature of the Status List Token after it has been fetched.
- 
+
 ### Read a Status List
 
 As a `Relying Party` be able to read a `Status List` at a specific index.
@@ -207,4 +208,3 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-

--- a/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/Types.kt
+++ b/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/Types.kt
@@ -15,8 +15,6 @@
  */
 package eu.europa.ec.eudi.statium
 
-import eu.europa.ec.eudi.statium.Status.Companion.applicationSpecificRange
-import eu.europa.ec.eudi.statium.Status.Companion.isApplicationSpecific
 import eu.europa.ec.eudi.statium.jose.RFC7519
 import eu.europa.ec.eudi.statium.misc.Base64UrlNoPadding
 import eu.europa.ec.eudi.statium.misc.BitsPerStatusSerializer

--- a/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/Types.kt
+++ b/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/Types.kt
@@ -220,13 +220,13 @@ public sealed interface Status : Comparable<Status> {
 
     /**
      * Indicates a valid referenced token
-     * It is available for a [BitsPerStatus]
+     * It is available for any [BitsPerStatus]
      */
     public data object Valid : Status
 
     /**
      * Indicates an invalid referenced token
-     * It is available for a [BitsPerStatus]
+     * It is available for any [BitsPerStatus]
      */
     public data object Invalid : Status
 
@@ -297,7 +297,7 @@ public sealed interface Status : Comparable<Status> {
                 BitsPerStatus.Eight -> 255u
             }
             require(statusValue <= maxValue) {
-                "Status value$statusValue cannot be represented with ${bitsPerStatus.bits} bits"
+                "Status $statusValue cannot be represented with ${bitsPerStatus.bits} bits"
             }
             Status(statusValue)
         }

--- a/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/GetStatusTest.kt
+++ b/lib/src/commonTest/kotlin/eu/europa/ec/eudi/statium/GetStatusTest.kt
@@ -52,7 +52,7 @@ private fun doTest(expectedStatus: Status, statusReference: StatusReference, clo
 
 private fun CoroutineScope.getStatus(clock: Clock, httpClientFactory: () -> HttpClient): GetStatus {
     val verifySignature = VerifyStatusListTokenSignature.Ignore
-    val getStatusListToken = GetStatusListToken.usingJwt(clock, httpClientFactory, verifySignature)
+    val getStatusListToken = GetStatusListToken.usingJwt(clock, httpClientFactory, verifySignature, kotlin.time.Duration.ZERO)
     val decompress = platformDecompress(coroutineContext)
     return GetStatus(getStatusListToken, decompress)
 }


### PR DESCRIPTION
This PR allows caller to define an allowed clock skew (as a positive duration) that is being taken into account to validate the `iat` and `exp` claims of the Status List Token.