### PR TITLE
Remove HTTP client factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,7 @@ Library provides for this use case the interface [GetStatusListToken](lib/src/co
 // Create an instance of GetStatusListToken using the usingJwt factory method
 val getStatusListToken: GetStatusListToken = GetStatusListToken.usingJwt(
     clock = Clock.System,
-    httpClientFactory = {
-        HttpClient {
-            // Configure your HTTP client here
-        }
-    },
+    httpClient = HttpClient(), // Just an example, remember to close the client when you're done!
     verifyStatusListTokenSignature = VerifyStatusListTokenSignature.Ignore, // Not for production
     allowedClockSkew = 5.minutes // Allow 5 minutes of clock skew (requires import: kotlin.time.Duration.Companion.minutes)
 )


### PR DESCRIPTION
Change the `GetStatusListToken` API to accept a `HttpClient` instance instead of a factory, and change the `GetStatusListTokenUsingJwt` implementation not to close the client, to allow reusing a single client between multiple requests.

Closes #39.