### PR TITLE
Migrate to Dokka v2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,9 @@ android.nonTransitiveRClass=true
 android.targetSdk=34
 android.minSdk=26
 
+# Dokka configuration
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+
 # Publishing settings
 namespace=eu.europa.ec.eudi.status
 group=eu.europa.ec.eudi

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,12 +5,12 @@ android-library = "8.5.2"
 kotlinx-serialization = "1.8.1"
 kotlinx-coroutines = "1.10.2"
 ktor = "3.2.3"
-maven-publish = "0.32.0"
+maven-publish = "0.34.0"
 spotless = "7.0.2"
 ktlint = "1.2.1"
 dependency-check = "12.1.1"
 kover = "0.9.1"
-dokka = "1.9.20"
+dokka = "2.1.0"
 
 [libraries]
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization" }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -1,7 +1,6 @@
 import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.KotlinMultiplatform
-import org.jetbrains.dokka.DokkaConfiguration
-import org.jetbrains.dokka.gradle.DokkaTask
+import org.jetbrains.dokka.gradle.engine.parameters.VisibilityModifier
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
@@ -155,40 +154,36 @@ spotless {
     }
 }
 
-tasks.withType<DokkaTask>().configureEach {
-    dokkaSourceSets {
-        configureEach {
-            // used as project name in the header
-            moduleName.set(properties["POM_NAME"].toString())
-            moduleVersion.set(project.version.toString())
+//
+// Configuration of Dokka engine
+//
+dokka {
+    // used as project name in the header
+    moduleName = properties["POM_NAME"].toString()
+    moduleVersion = project.version.toString()
 
-            documentedVisibilities.set(
-                setOf(
-                    DokkaConfiguration.Visibility.PUBLIC,
-                    DokkaConfiguration.Visibility.PROTECTED,
-                ),
-            )
+    dokkaSourceSets.configureEach {
+        documentedVisibilities = setOf(VisibilityModifier.Public, VisibilityModifier.Protected)
 
-            val remoteSourceUrl =
-                System.getenv()["GIT_REF_NAME"]?.let {
-                    URI.create("${properties["POM_SCM_URL"]}/tree/$it/${project.layout.projectDirectory.asFile.name}/src").toURL()
+        val remoteSourceUrl =
+            System.getenv()["GIT_REF_NAME"]?.let {
+                URI.create("${properties["POM_SCM_URL"]}/tree/$it/${project.layout.projectDirectory.asFile.name}/src")
+            }
+        remoteSourceUrl
+            ?.let {
+                sourceLink {
+                    localDirectory = projectDir.resolve("src")
+                    remoteUrl = it
+                    remoteLineSuffix = "#L"
                 }
-            remoteSourceUrl
-                ?.let {
-                    sourceLink {
-                        localDirectory.set(projectDir.resolve("src"))
-                        remoteUrl.set(it)
-                        remoteLineSuffix.set("#L")
-                    }
-                }
-        }
+            }
     }
 }
 
 mavenPublishing {
     configure(
         KotlinMultiplatform(
-            javadocJar = JavadocJar.Dokka(tasks.dokkaHtml.name),
+            javadocJar = JavadocJar.Dokka(tasks.dokkaGeneratePublicationHtml),
             sourcesJar = true,
             androidVariantsToPublish = listOf("release"),
         ),


### PR DESCRIPTION
This PR:

1. Upgrades Dokka to v2 and migrates the configuration
2. Upgrades Maven Publish Plugin to the latest version to ensure full support for Dokka v2
3. Disables any compatibility helpers that might be registered by Dokka v2